### PR TITLE
Refine toolbox module docs and typing

### DIFF
--- a/src/windows_toolbox.py
+++ b/src/windows_toolbox.py
@@ -1,60 +1,111 @@
-#!/usr/bin/env python
-#
-# files: windows_toolbox.py
-#
-# revision history:
-# 20251219 (XX): initial version
-#
-# This file contains a Python implementation of:
-#   A Windows Toolbox application that implements SHIFT triple-press snapping/restoring of windows,
-#   and an Explorer View Manager that adjusts Explorer settings (such as view mode, grouping,
-#   and sorting) by sending hotkeys.
-#
-#------------------------------------------------------------------------------
+"""Windows toolbox application entry point.
 
-# import required system modules
-import os
+This module hosts the PyQt-based user interface and the supporting backend
+helpers that implement two core features:
+
+* A "Shift" triple-press shortcut that centers and resizes the foreground
+  window or restores it to its original dimensions.
+* A background Explorer manager that normalises view settings in open Windows
+  Explorer instances.
+
+The previous iteration of this module featured dated documentation blocks and
+loosely typed helpers. The file has been refreshed to adhere to PEP 8/257 and
+NumPy docstring guidelines and now includes richer typing hints so that future
+refactors remain maintainable.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import logging
 import sys
 import time
-import json
-import psutil
-import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Final, Iterable, Iterator, Optional, Tuple, TypedDict, cast
+
+from ctypes import wintypes
+
 import keyboard
-import ctypes
-import win32gui
+import psutil
+import pywintypes
 import win32api
-import win32con
 import win32com.client
+import win32gui
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-#------------------------------------------------------------------------------
-#
-# global variables are listed here
-#
-#------------------------------------------------------------------------------
+if sys.platform != "win32":
+    raise OSError("windows_toolbox requires a Windows environment")
 
-# Get user32 from ctypes and define window-related constants
+logger = logging.getLogger(__name__)
+if not logging.getLogger().handlers:
+    logging.basicConfig(level=logging.INFO)
+
 user32 = ctypes.windll.user32
 SW_RESTORE = 9
 MONITOR_DEFAULTTONEAREST = 2
 
-# Define program-specific constants
-PROGRAM_NAME = "windows_toolbox"   # Name of the program
-SETTINGS_FILENAME = "snap_and_restore_settings.json"   # Settings file name
-ICON_FILENAME = "icon.ico"         # Icon file name
+PROGRAM_NAME: Final[str] = "windows_toolbox"
+SETTINGS_FILENAME: Final[str] = "snap_and_restore_settings.json"
+ICON_FILENAME: Final[str] = "icon.ico"
 
-# Define key mapping for hotkey processing
-KEY_MAP = {
-    "Left Shift": "shift",
-    "Right Shift": "right shift",
-    "Left Ctrl": "ctrl",
-    "Right Ctrl": "right ctrl",
-    "Left Alt": "alt",
-    "Right Alt": "right alt",
-    "A": "a",
-    "B": "b",
-    "C": "c"
+
+class Settings(TypedDict):
+    """Structured settings for the toolbox."""
+
+    enable_snap_restore: bool
+    enable_explorer_view: bool
+    hotkey: str
+    presses: int
+    interval: int
+    width_pct: int
+    height_pct: int
+    explorer_viewmode: int
+    explorer_sortcolumn: str
+    explorer_sortascending: bool
+    explorer_enablegrouping: bool
+    explorer_autosizecolumns: bool
+    explorer_one_shot_ctrl_plus: bool
+
+
+DEFAULT_SETTINGS: Final[Settings] = {
+    "enable_snap_restore": True,
+    "enable_explorer_view": True,
+    "hotkey": "shift",
+    "presses": 3,
+    "interval": 1050,
+    "width_pct": 76,
+    "height_pct": 76,
+    "explorer_viewmode": 4,
+    "explorer_sortcolumn": "System.ItemNameDisplay",
+    "explorer_sortascending": True,
+    "explorer_enablegrouping": False,
+    "explorer_autosizecolumns": True,
+    "explorer_one_shot_ctrl_plus": True,
 }
+
+
+@dataclass(slots=True)
+class WindowGeometry:
+    """Bounds of a top-level window."""
+
+    left: int
+    top: int
+    width: int
+    height: int
+
+    @property
+    def right(self) -> int:
+        """Right-most coordinate of the window rectangle."""
+
+        return self.left + self.width
+
+    @property
+    def bottom(self) -> int:
+        """Bottom coordinate of the window rectangle."""
+
+        return self.top + self.height
 
 #------------------------------------------------------------------------------
 #
@@ -62,199 +113,142 @@ KEY_MAP = {
 #
 #------------------------------------------------------------------------------
 
-def resource_path(relative_path):
+def resource_path(relative_path: str) -> Path:
+    """Resolve a resource path for frozen and non-frozen deployments.
+
+    Parameters
+    ----------
+    relative_path
+        File name relative to the project root.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute path to the requested resource.
     """
-    function: resource_path
 
-    arguments:
-      relative_path: (string) relative file path
+    base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent))
+    return base_path / relative_path
 
-    return:
-      (string) absolute path to the resource
 
-    description:
-      Returns the absolute path to a resource, working whether the application is
-      bundled (using _MEIPASS) or run as a script.
-    """
-    base_path = getattr(sys, '_MEIPASS', os.path.abspath(".")) if hasattr(sys, '_MEIPASS') else os.path.abspath(".")
-    return os.path.join(base_path, relative_path)
+def get_settings_file_path() -> Path:
+    """Return the expected settings file location."""
 
-def get_settings_file_path():
-    """
-    function: get_settings_file_path
+    if hasattr(sys, "_MEIPASS"):
+        return Path(sys.executable).resolve().parent / SETTINGS_FILENAME
+    return Path(__file__).resolve().parent / SETTINGS_FILENAME
 
-    arguments:
-      none
 
-    return:
-      (string) the absolute path to the settings file
+def _merge_settings(source: Dict[str, Any], destination: Settings) -> Settings:
+    """Merge user settings into defaults while filtering unknown keys."""
 
-    description:
-      Determines the location of the settings file depending on whether the program is bundled.
-    """
-    if hasattr(sys, '_MEIPASS'):
-        return os.path.join(os.path.dirname(sys.executable), SETTINGS_FILENAME)
-    else:
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        return os.path.join(script_dir, SETTINGS_FILENAME)
+    merged: Settings = destination.copy()
+    for key, value in source.items():
+        if key in destination:
+            merged[key] = value
+        else:
+            logger.debug("Ignoring unknown settings key '%s'", key)
+    return merged
 
-def load_settings():
-    """
-    function: load_settings
 
-    arguments:
-      none
+def load_settings() -> Settings:
+    """Load settings from disk, falling back to defaults on failure."""
 
-    return:
-      (dict) settings loaded from file or default settings
-
-    description:
-      Loads settings from a JSON file if available; otherwise returns default settings.
-    """
-    default_settings = {
-        "enable_snap_restore": True,
-        "enable_explorer_view": True,
-        "hotkey": "Left Shift",
-        "presses": 3,
-        "interval": 1050,
-        "width_pct": 76,
-        "height_pct": 76,
-        "explorer_viewmode": 4,  # 4 => Details
-        "explorer_sortcolumn": "System.ItemNameDisplay",
-        "explorer_sortascending": True,
-        "explorer_enablegrouping": False,
-        "explorer_autosizecolumns": True,      # repeated approach
-        "explorer_one_shot_ctrl_plus": True    # one-shot on folder changes
-    }
     path = get_settings_file_path()
-    if not os.path.exists(path):
-        return default_settings
+    if not path.exists():
+        return cast(Settings, DEFAULT_SETTINGS.copy())
+
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        for k in default_settings:
-            if k not in data:
-                data[k] = default_settings[k]
-        return data
-    except:
-        return default_settings
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return cast(Settings, DEFAULT_SETTINGS.copy())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to load settings file %s: %s", path, exc)
+        return cast(Settings, DEFAULT_SETTINGS.copy())
 
-def save_settings(settings):
-    """
-    function: save_settings
+    if not isinstance(payload, dict):
+        logger.warning("Unexpected settings format in %s; using defaults", path)
+        return cast(Settings, DEFAULT_SETTINGS.copy())
 
-    arguments:
-      settings: (dict) settings to save
+    return _merge_settings(payload, DEFAULT_SETTINGS)
 
-    return:
-      none
 
-    description:
-      Saves the provided settings dictionary to a JSON file.
-    """
+def save_settings(settings: Settings) -> None:
+    """Persist toolbox settings to disk."""
+
     path = get_settings_file_path()
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(settings, f, indent=2)
+    try:
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(settings, handle, indent=2)
+    except OSError as exc:
+        logger.error("Unable to save settings to %s: %s", path, exc)
 
-def is_explorer_foreground():
-    """
-    function: is_explorer_foreground
+def is_explorer_foreground() -> bool:
+    """Return ``True`` if the foreground window belongs to Explorer."""
 
-    arguments:
-      none
-
-    return:
-      (bool) True if the current foreground window belongs to explorer.exe, False otherwise
-
-    description:
-      Checks if the current foreground window is part of Windows Explorer.
-    """
     fg_hwnd = user32.GetForegroundWindow()
     if not fg_hwnd:
         return False
+
     pid = ctypes.c_ulong()
     user32.GetWindowThreadProcessId(fg_hwnd, ctypes.byref(pid))
     try:
-        proc = psutil.Process(pid.value)
-        return (proc.name().lower() == "explorer.exe")
-    except:
+        process = psutil.Process(pid.value)
+        return process.name().lower() == "explorer.exe"
+    except (psutil.Error, OSError) as exc:
+        logger.debug("Failed to resolve foreground process: %s", exc)
         return False
 
-def send_ctrl_plus():
-    """
-    function: send_ctrl_plus
 
-    arguments:
-      none
+def send_ctrl_plus() -> None:
+    """Simulate a single ``Ctrl`` + ``+`` keyboard press."""
 
-    return:
-      none
+    try:
+        keyboard.press_and_release("ctrl+add")
+    except (keyboard.KeyboardException, ValueError) as exc:
+        logger.debug("Unable to send Ctrl+Plus hotkey: %s", exc)
 
-    description:
-      Simulates pressing Ctrl + numeric keypad '+' once.
-    """
-    keyboard.press_and_release('ctrl+add')
 
-def unmaximize_if_needed(hwnd):
-    """
-    function: unmaximize_if_needed
+def unmaximize_if_needed(hwnd: int) -> None:
+    """Restore a maximised window before applying custom geometry."""
 
-    arguments:
-      hwnd: (handle) window handle
-
-    return:
-      none
-
-    description:
-      If the window is maximized, restores it to normal size.
-    """
     if user32.IsZoomed(hwnd):
         user32.ShowWindow(hwnd, SW_RESTORE)
 
-def get_window_hash(hwnd):
-    """
-    function: get_window_hash
 
-    arguments:
-      hwnd: (handle) window handle
+def get_window_hash(hwnd: int) -> str:
+    """Return a string key that uniquely identifies a window."""
 
-    return:
-      (string) a unique hash representing the window
-
-    description:
-      Constructs a unique identifier for a window based on its process ID,
-      class name, and window text.
-    """
     pid = ctypes.c_ulong()
     user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
-    pid_val = pid.value
-    class_name = win32gui.GetClassName(hwnd)
-    window_text = win32gui.GetWindowText(hwnd)
-    return f"{pid_val}_{class_name}_{window_text}"
+    pid_value = pid.value
+    try:
+        class_name = win32gui.GetClassName(hwnd)
+        window_text = win32gui.GetWindowText(hwnd)
+    except win32gui.error as exc:
+        logger.debug("Unable to read window attributes for %s: %s", hwnd, exc)
+        return str(pid_value or hwnd)
+    return f"{pid_value}_{class_name}_{window_text}"
 
-def find_child_window(parent_hwnd, child_class):
-    """
-    function: find_child_window
 
-    arguments:
-      parent_hwnd: (handle) parent window handle
-      child_class: (string) class name of child window to find
+def find_child_window(parent_hwnd: int, child_class: str) -> Optional[int]:
+    """Find the first child window with the supplied class name."""
 
-    return:
-      (handle) child window handle if found, else None
-
-    description:
-      Searches for a child window with a specific class name under the given parent.
-    """
     direct = win32gui.FindWindowEx(parent_hwnd, 0, child_class, None)
     if direct:
         return direct
 
-    found = []
+    found: list[int] = []
+
     def enum_callback(hwnd, _):
-        cname = win32gui.GetClassName(hwnd)
+        try:
+            cname = win32gui.GetClassName(hwnd)
+        except win32gui.error:
+            return
         if cname.lower() == child_class.lower():
             found.append(hwnd)
+
     win32gui.EnumChildWindows(parent_hwnd, enum_callback, None)
     return found[0] if found else None
 
@@ -265,58 +259,40 @@ def find_child_window(parent_hwnd, child_class):
 #------------------------------------------------------------------------------
 
 class ShiftTriplePress(QtCore.QObject):
+    """Detect three ``Shift`` taps and toggle the active window geometry.
+
+    Parameters
+    ----------
+    settings : Settings
+        Toolbox settings dictionary.
+    parent : QtCore.QObject, optional
+        Optional QObject parent used by Qt for ownership tracking.
     """
-    Class: ShiftTriplePress
 
-    arguments:
-     settings: (dict) configuration settings for snap & restore functionality
-     parent: (QObject) parent object (default None)
-
-    description:
-     Implements SHIFT triple-press logic that avoids counting a continuous hold as multiple presses.
-     Once the required number of distinct SHIFT presses within a specified interval is detected,
-     the active window is either snapped (centered and resized) or restored to its original size.
-    """
-    def __init__(self, settings, parent=None):
-        """
-        method: __init__
-
-        arguments:
-         settings: (dict) configuration settings
-         parent: (QObject) parent object (default None)
-
-        return:
-         none
-
-        description:
-         Initializes the ShiftTriplePress instance, hooks the SHIFT key, and sets initial parameters.
-        """
+    def __init__(self, settings: Settings, parent: Optional[QtCore.QObject] = None):
+        """Initialise the triple-press handler and register the keyboard hook."""
         super().__init__(parent)
-        self.settings = settings
+        self.settings: Settings = settings
         self.shift_held = False
-        self.press_times = []
-        self.required_presses = self.settings["presses"]
-        self.interval_s = self.settings["interval"] / 1000.0
+        self.press_times: list[float] = []
+        self.required_presses = int(self.settings["presses"])
+        self.interval_s = float(self.settings["interval"]) / 1000.0
 
         # Store original window sizes for restoration
-        self.original_sizes = {}
+        self.original_sizes: dict[str, WindowGeometry] = {}
 
-        # Hook SHIFT key events
-        keyboard.hook_key('shift', self.on_shift_event, suppress=False)
+        hotkey_setting = str(self.settings.get("hotkey", "shift")).strip().lower()
+        if hotkey_setting in {"left shift", "right shift"}:
+            hotkey_setting = "shift"
+        self.hotkey = hotkey_setting
+        self._hook: Optional[Any] = None
+        try:
+            self._hook = keyboard.hook_key(self.hotkey, self.on_shift_event, suppress=False)
+        except (keyboard.KeyboardException, ValueError) as exc:
+            logger.error("Failed to register hotkey '%s': %s", self.hotkey, exc)
 
-    def on_shift_event(self, event):
-        """
-        method: on_shift_event
-
-        arguments:
-         event: (keyboard event) the key event
-
-        return:
-         none
-
-        description:
-         Processes SHIFT key events to detect distinct presses and triggers snap or restore.
-        """
+    def on_shift_event(self, event: keyboard.KeyboardEvent) -> None:
+        """Handle keyboard events produced by the chosen hotkey."""
         if not self.settings.get("enable_snap_restore", False):
             return
 
@@ -329,40 +305,45 @@ class ShiftTriplePress(QtCore.QObject):
                 self.press_times.append(now)
                 if len(self.press_times) == self.required_presses:
                     self.press_times.clear()
-                    if keyboard.is_pressed('ctrl'):
+                    try:
+                        ctrl_pressed = keyboard.is_pressed('ctrl')
+                    except keyboard.KeyboardException:
+                        ctrl_pressed = False
+                    if ctrl_pressed:
                         self.center_original_size()
                     else:
                         self.center_and_resize_window()
         elif event.event_type == 'up':
             self.shift_held = False
 
-    def center_and_resize_window(self):
-        """
-        method: center_and_resize_window
+    def update_timing(self, presses: int, interval_ms: int) -> None:
+        """Update cached timing parameters after a settings change."""
 
-        arguments:
-         none
+        self.required_presses = max(1, int(presses))
+        self.interval_s = max(0.0, float(interval_ms) / 1000.0)
 
-        return:
-         none
+    def stop(self) -> None:
+        """Detach the keyboard hook when shutting down the application."""
 
-        description:
-         Centers and resizes the currently active window based on configured width and height percentages.
-        """
+        if self._hook is not None:
+            keyboard.unhook(self._hook)
+            self._hook = None
+
+    def center_and_resize_window(self) -> None:
+        """Centre the active window using the configured percentages."""
         hwnd = user32.GetForegroundWindow()
         if not hwnd:
             return
         unmaximize_if_needed(hwnd)
 
-        rect = ctypes.wintypes.RECT()
-        user32.GetWindowRect(hwnd, ctypes.byref(rect))
-        o_left, o_top = rect.left, rect.top
-        o_width = rect.right - rect.left
-        o_height = rect.bottom - rect.top
+        rect = wintypes.RECT()
+        if not user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+            logger.debug("GetWindowRect failed for hwnd %s", hwnd)
+            return
+        original_geometry = WindowGeometry(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top)
 
-        w_hash = get_window_hash(hwnd)
-        if w_hash not in self.original_sizes:
-            self.original_sizes[w_hash] = (o_left, o_top, o_width, o_height)
+        window_key = get_window_hash(hwnd)
+        self.original_sizes.setdefault(window_key, original_geometry)
 
         width_pct = self.settings["width_pct"] / 100.0
         height_pct = self.settings["height_pct"] / 100.0
@@ -370,52 +351,51 @@ class ShiftTriplePress(QtCore.QObject):
         monitor = user32.MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)
         if not monitor:
             return
-        mon_info = win32api.GetMonitorInfo(monitor)
-        (m_left, m_top, m_right, m_bottom) = mon_info["Monitor"]
-        m_w = m_right - m_left
-        m_h = m_bottom - m_top
+        try:
+            monitor_info = win32api.GetMonitorInfo(monitor)
+        except win32api.error as exc:
+            logger.debug("GetMonitorInfo failed: %s", exc)
+            return
+        (m_left, m_top, m_right, m_bottom) = monitor_info["Monitor"]
+        monitor_width = m_right - m_left
+        monitor_height = m_bottom - m_top
 
-        new_w = int(m_w * width_pct)
-        new_h = int(m_h * height_pct)
-        new_left = m_left + (m_w - new_w) // 2
-        new_top = m_top + (m_h - new_h) // 2
+        new_width = int(monitor_width * width_pct)
+        new_height = int(monitor_height * height_pct)
+        new_left = m_left + (monitor_width - new_width) // 2
+        new_top = m_top + (monitor_height - new_height) // 2
 
-        user32.MoveWindow(hwnd, new_left, new_top, new_w, new_h, True)
+        if not user32.MoveWindow(hwnd, new_left, new_top, new_width, new_height, True):
+            logger.debug("MoveWindow failed when resizing %s", hwnd)
 
-    def center_original_size(self):
-        """
-        method: center_original_size
-
-        arguments:
-         none
-
-        return:
-         none
-
-        description:
-         Restores the active window to its original size and centers it.
-        """
+    def center_original_size(self) -> None:
+        """Restore stored geometry and centre the window on screen."""
         hwnd = user32.GetForegroundWindow()
         if not hwnd:
             return
         unmaximize_if_needed(hwnd)
 
-        w_hash = get_window_hash(hwnd)
-        if w_hash not in self.original_sizes:
+        window_key = get_window_hash(hwnd)
+        original = self.original_sizes.get(window_key)
+        if not original:
             return
-        (o_left, o_top, o_w, o_h) = self.original_sizes[w_hash]
 
         monitor = user32.MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)
         if not monitor:
             return
-        mon_info = win32api.GetMonitorInfo(monitor)
-        (m_left, m_top, m_right, m_bottom) = mon_info["Monitor"]
-        m_w = m_right - m_left
-        m_h = m_bottom - m_top
+        try:
+            monitor_info = win32api.GetMonitorInfo(monitor)
+        except win32api.error as exc:
+            logger.debug("GetMonitorInfo failed: %s", exc)
+            return
+        (m_left, m_top, m_right, m_bottom) = monitor_info["Monitor"]
+        monitor_width = m_right - m_left
+        monitor_height = m_bottom - m_top
 
-        new_left = m_left + (m_w - o_w) // 2
-        new_top = m_top + (m_h - o_h) // 2
-        user32.MoveWindow(hwnd, new_left, new_top, o_w, o_h, True)
+        new_left = m_left + (monitor_width - original.width) // 2
+        new_top = m_top + (monitor_height - original.height) // 2
+        if not user32.MoveWindow(hwnd, new_left, new_top, original.width, original.height, True):
+            logger.debug("MoveWindow failed when restoring %s", hwnd)
 
 #------------------------------------------------------------------------------
 #
@@ -424,72 +404,36 @@ class ShiftTriplePress(QtCore.QObject):
 #------------------------------------------------------------------------------
 
 class ExplorerViewManager(QtCore.QObject):
+    """Normalise view settings across open Explorer windows.
+
+    Parameters
+    ----------
+    settings : Settings
+        Toolbox settings dictionary.
+    parent : QtCore.QObject, optional
+        Optional QObject parent.
     """
-    Class: ExplorerViewManager
 
-    arguments:
-     settings: (dict) configuration settings for Explorer view adjustments
-     parent: (QObject) parent object (default None)
-
-    description:
-     Implements a polling approach that, every 4 seconds, either sends repeated 'Ctrl+ +'
-     commands if Explorer is in Details view or performs a one-shot 'Ctrl+ +' if a folder
-     change is detected.
-    """
-    def __init__(self, settings, parent=None):
-        """
-        method: __init__
-
-        arguments:
-         settings: (dict) configuration settings
-         parent: (QObject) parent object (default None)
-
-        return:
-         none
-
-        description:
-         Initializes the ExplorerViewManager instance and starts the polling timer.
-        """
+    def __init__(self, settings: Settings, parent: Optional[QtCore.QObject] = None):
         super().__init__(parent)
-        self.settings = settings
-        self.enabled = self.settings["enable_explorer_view"]
-        self.last_paths = {}  # Dictionary: {hwnd: last_known_path}
+        self.settings: Settings = settings
+        self.enabled = bool(self.settings["enable_explorer_view"])
+        self.last_paths: dict[int, str] = {}
 
-        self.timer = QtCore.QTimer()
+        self.timer = QtCore.QTimer(self)
         self.timer.setInterval(4000)  # Poll every 4 seconds
         self.timer.timeout.connect(self.poll_explorer)
         if self.enabled:
             self.timer.start()
 
-    def set_settings(self, settings):
-        """
-        method: set_settings
+    def set_settings(self, settings: Settings) -> None:
+        """Replace stored settings and update the enabled state."""
 
-        arguments:
-         settings: (dict) updated configuration settings
-
-        return:
-         none
-
-        description:
-         Updates the settings and reconfigures the manager's enabled state.
-        """
         self.settings = settings
         self.set_enabled(self.settings["enable_explorer_view"])
 
-    def set_enabled(self, enable):
-        """
-        method: set_enabled
-
-        arguments:
-         enable: (bool) whether to enable the Explorer view manager
-
-        return:
-         none
-
-        description:
-         Enables or disables the polling timer and clears stored paths if disabled.
-        """
+    def set_enabled(self, enable: bool) -> None:
+        """Toggle the polling timer and clear state when disabled."""
         self.enabled = enable
         if enable:
             if not self.timer.isActive():
@@ -498,89 +442,99 @@ class ExplorerViewManager(QtCore.QObject):
             self.timer.stop()
             self.last_paths.clear()
 
-    def poll_explorer(self):
-        """
-        method: poll_explorer
-
-        arguments:
-         none
-
-        return:
-         none
-
-        description:
-         Polls Explorer windows and sends hotkey commands based on the configured approach.
-        """
+    def poll_explorer(self) -> None:
+        """Inspect Explorer windows and apply configured adjustments."""
         if not self.enabled:
             return
 
-        shell = win32com.client.Dispatch("Shell.Application")
+        for hwnd, doc in self._iter_explorer_windows():
+            self._handle_folder_change(hwnd, doc)
+            self._apply_repeated_adjustments(doc)
+
+    def _iter_explorer_windows(self) -> Iterable[Tuple[int, object]]:
+        """Yield handles and documents for active Explorer windows."""
+
+        try:
+            shell = win32com.client.Dispatch("Shell.Application")
+        except pywintypes.com_error as exc:
+            logger.debug("Failed to dispatch Shell.Application: %s", exc)
+            return
+
         for window in shell.Windows():
             if not window:
                 continue
             try:
                 name_lower = window.Name.lower()
-                if "explorer" not in name_lower:
-                    continue
-            except:
+            except (AttributeError, pywintypes.com_error):
                 continue
-
-            doc = window.Document
+            if "explorer" not in name_lower:
+                continue
+            try:
+                doc = window.Document
+            except (AttributeError, pywintypes.com_error):
+                continue
             if not doc:
                 continue
+            yield window.HWND, doc
 
-            hwnd = window.HWND
-            # One-shot approach for folder changes
-            if self.settings.get("explorer_one_shot_ctrl_plus", False):
-                new_path = ""
-                try:
-                    new_path = doc.Folder.Self.Path
-                except:
-                    pass
-                old_path = self.last_paths.get(hwnd, None)
-                if new_path and new_path != old_path:
-                    self.last_paths[hwnd] = new_path
-                    if is_explorer_foreground():
-                        send_ctrl_plus()
+    def _handle_folder_change(self, hwnd: int, doc: object) -> None:
+        """Trigger a one-shot column autosize when the folder path changes."""
 
-            # Repeated approach if enabled
-            if self.settings.get("explorer_autosizecolumns", False):
-                try:
-                    doc.CurrentViewMode = int(self.settings.get("explorer_viewmode", 4))
-                except:
-                    pass
+        if not self.settings.get("explorer_one_shot_ctrl_plus", False):
+            return
+        new_path = ""
+        try:
+            new_path = doc.Folder.Self.Path
+        except (AttributeError, pywintypes.com_error):
+            return
+        old_path = self.last_paths.get(hwnd)
+        if new_path and new_path != old_path:
+            self.last_paths[hwnd] = new_path
+            if is_explorer_foreground():
+                send_ctrl_plus()
 
-                if not self.settings.get("explorer_enablegrouping", False):
-                    try:
-                        doc.GroupBy = "System.Null"
-                    except:
-                        pass
-                else:
-                    try:
-                        doc.GroupBy = self.settings["explorer_sortcolumn"]
-                    except:
-                        pass
+    def _apply_repeated_adjustments(self, doc: object) -> None:
+        """Apply persistent Explorer tweaks such as autosizing columns."""
 
-                try:
-                    doc.SortColumns = self.settings["explorer_sortcolumn"]
-                    doc.SortAscending = bool(self.settings["explorer_sortascending"])
-                except:
-                    pass
+        if not self.settings.get("explorer_autosizecolumns", False):
+            return
 
-                mode = 0
-                try:
-                    mode = doc.CurrentViewMode
-                except:
-                    pass
-                if mode == 4:
-                    for _ in range(5):
-                        send_ctrl_plus()
-                        time.sleep(0.1)
+        try:
+            doc.CurrentViewMode = int(self.settings.get("explorer_viewmode", 4))
+        except (AttributeError, pywintypes.com_error, ValueError) as exc:
+            logger.debug("Unable to set view mode: %s", exc)
 
-                try:
-                    doc.Refresh()
-                except:
-                    pass
+        if not self.settings.get("explorer_enablegrouping", False):
+            try:
+                doc.GroupBy = "System.Null"
+            except (AttributeError, pywintypes.com_error) as exc:
+                logger.debug("Unable to disable grouping: %s", exc)
+        else:
+            try:
+                doc.GroupBy = self.settings["explorer_sortcolumn"]
+            except (AttributeError, pywintypes.com_error, KeyError) as exc:
+                logger.debug("Unable to set grouping: %s", exc)
+
+        try:
+            doc.SortColumns = self.settings["explorer_sortcolumn"]
+            doc.SortAscending = bool(self.settings["explorer_sortascending"])
+        except (AttributeError, pywintypes.com_error, KeyError) as exc:
+            logger.debug("Unable to set sorting: %s", exc)
+
+        try:
+            mode = int(getattr(doc, "CurrentViewMode", 0))
+        except (AttributeError, ValueError):
+            mode = 0
+
+        if mode == 4:
+            for _ in range(5):
+                send_ctrl_plus()
+                time.sleep(0.1)
+
+        try:
+            doc.Refresh()
+        except (AttributeError, pywintypes.com_error) as exc:
+            logger.debug("Unable to refresh view: %s", exc)
 
 #------------------------------------------------------------------------------
 #
@@ -589,34 +543,16 @@ class ExplorerViewManager(QtCore.QObject):
 #------------------------------------------------------------------------------
 
 class ToolboxMainWindow(QtWidgets.QMainWindow):
-    """
-    Class: ToolboxMainWindow
+    """Main window stitching together the toolbox features."""
 
-    arguments:
-     none
-
-    description:
-     Main window that combines the SHIFT triple-press snap & restore logic with the Explorer View Manager.
-    """
-    def __init__(self):
-        """
-        method: __init__
-
-        arguments:
-         none
-
-        return:
-         none
-
-        description:
-         Initializes the main window, loads settings, sets up UI components, and configures system tray functionality.
-        """
+    def __init__(self) -> None:
+        """Build the UI, load settings, and start helper managers."""
         super().__init__()
         icon_file = resource_path(ICON_FILENAME)
-        self.setWindowIcon(QtGui.QIcon(icon_file))
+        self.setWindowIcon(QtGui.QIcon(str(icon_file)))
         self.setWindowTitle("Windows Toolbox (Repeated Ctrl+ +)")
         self.setGeometry(100, 100, 700, 640)
-        self.settings = load_settings()
+        self.settings: Settings = load_settings()
 
         # Initialize SHIFT triple-press manager
         self.shift_manager = ShiftTriplePress(self.settings)
@@ -768,7 +704,7 @@ class ToolboxMainWindow(QtWidgets.QMainWindow):
         self.setCentralWidget(container)
 
         # Setup system tray functionality
-        icon_ = QtGui.QIcon(icon_file)
+        icon_ = QtGui.QIcon(str(icon_file))
         self.tray_icon = QtWidgets.QSystemTrayIcon(self)
         self.tray_icon.setIcon(icon_)
         self.tray_icon.setToolTip(PROGRAM_NAME)
@@ -781,37 +717,52 @@ class ToolboxMainWindow(QtWidgets.QMainWindow):
         self.tray_icon.activated.connect(self.on_tray_icon_double_click)
         self.tray_icon.show()
 
-    def toggle_snap(self, state):
+    def toggle_snap(self, state: int) -> None:
+        """Enable or disable the Shift triple-press workflow."""
+
         self.settings["enable_snap_restore"] = (state == QtCore.Qt.Checked)
 
-    def toggle_explorer(self, state):
+    def toggle_explorer(self, state: int) -> None:
+        """Enable or disable the Explorer manager."""
+
         self.settings["enable_explorer_view"] = (state == QtCore.Qt.Checked)
         self.explorer_manager.set_settings(self.settings)
 
-    def update_press_label(self):
+    def update_press_label(self) -> None:
+        """Refresh the triple-press count label."""
+
         val = self.press_slider.value()
         self.press_label.setText(f"Times Pressed: {val}")
 
-    def update_interval_label(self):
+    def update_interval_label(self) -> None:
+        """Refresh the interval label."""
+
         val = self.interval_slider.value()
         self.interval_label.setText(f"Press Interval (ms): {val}")
 
-    def update_horiz_label(self):
+    def update_horiz_label(self) -> None:
+        """Refresh the width label."""
+
         val = self.horiz_slider.value()
         self.horiz_label.setText(f"Width Percentage: {val}%")
 
-    def update_vert_label(self):
+    def update_vert_label(self) -> None:
+        """Refresh the height label."""
+
         val = self.vert_slider.value()
         self.vert_label.setText(f"Height Percentage: {val}%")
 
-    def save_all(self):
+    def save_all(self) -> None:
+        """Persist updated settings and reconfigure managers."""
+
         self.settings["enable_snap_restore"] = self.snap_checkbox.isChecked()
         self.settings["presses"] = self.press_slider.value()
         self.settings["interval"] = self.interval_slider.value()
         self.settings["width_pct"] = self.horiz_slider.value()
         self.settings["height_pct"] = self.vert_slider.value()
         self.settings["enable_explorer_view"] = self.explorer_checkbox.isChecked()
-        self.settings["explorer_viewmode"] = self.viewmode_combo.currentData()
+        view_mode_data = self.viewmode_combo.currentData()
+        self.settings["explorer_viewmode"] = int(view_mode_data) if view_mode_data is not None else 4
         self.settings["explorer_sortcolumn"] = self.sortcol_edit.text().strip()
         self.settings["explorer_sortascending"] = self.sortasc_checkbox.isChecked()
         self.settings["explorer_enablegrouping"] = self.grouping_checkbox.isChecked()
@@ -821,74 +772,53 @@ class ToolboxMainWindow(QtWidgets.QMainWindow):
         save_settings(self.settings)
 
         # Update SHIFT manager parameters
-        self.shift_manager.required_presses = self.settings["presses"]
-        self.shift_manager.interval_s = self.settings["interval"] / 1000.0
+        self.shift_manager.update_timing(self.settings["presses"], self.settings["interval"])
 
         # Update Explorer manager settings
         self.explorer_manager.set_settings(self.settings)
 
-    def on_tray_icon_double_click(self, reason):
+    def on_tray_icon_double_click(self, reason: QtWidgets.QSystemTrayIcon.ActivationReason) -> None:
+        """Restore the window when the tray icon is double-clicked."""
+
         if reason == QtWidgets.QSystemTrayIcon.DoubleClick:
             self.showNormal()
             self.activateWindow()
 
-    def close_app(self):
-        keyboard.unhook_all()
+    def close_app(self) -> None:
+        """Tear down managers and exit the application."""
+
+        self.shift_manager.stop()
+        self.explorer_manager.set_enabled(False)
         self.tray_icon.hide()
         QtWidgets.QApplication.quit()
 
-    def closeEvent(self, event):
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+        """Minimise to tray instead of closing immediately."""
+
         event.ignore()
         self.showMinimized()
 
-    def changeEvent(self, event):
+    def changeEvent(self, event: QtCore.QEvent) -> None:
+        """Hide the window when minimised to reduce clutter."""
+
         if event.type() == QtCore.QEvent.WindowStateChange:
             if self.isMinimized():
                 QtCore.QTimer.singleShot(0, self.hide)
         super().changeEvent(event)
 
 class ToolboxApp(QtWidgets.QApplication):
-    """
-    Class: ToolboxApp
+    """Qt application wrapper that owns the main window."""
 
-    arguments:
-     argv: (list) command line arguments
-
-    description:
-     Main application class that creates and shows the ToolboxMainWindow.
-    """
-    def __init__(self, argv):
-        """
-        method: __init__
-
-        arguments:
-         argv: (list) command line arguments
-
-        return:
-         none
-
-        description:
-         Initializes the ToolboxApp and creates the main window.
-        """
+    def __init__(self, argv: Iterable[str]):
+        """Create the application object and show the main window."""
         super().__init__(argv)
         self.main_window = ToolboxMainWindow()
         self.main_window.show()
 
-def main():
-    """
-    method: main
-
-    arguments:
-     none
-
-    return:
-     none
-
-    description:
-     Main routine to initialize and execute the ToolboxApp.
-    """
+def main() -> None:
+    """Entrypoint that initialises and executes the Qt event loop."""
     app = ToolboxApp(sys.argv)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- modernize the module documentation and configuration utilities with a structured `Settings` TypedDict and explicit typing throughout the helpers
- refresh the Shift triple-press workflow to use the typed settings, cleaned geometry tracking, and concise docstrings that follow PEP 257/NumPy guidance
- streamline the Explorer manager and main window classes with clearer documentation, parented timers, and consistent settings propagation

## Testing
- python -m compileall src/windows_toolbox.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f0c1e7b0832c96b19bd38bf7b3a8